### PR TITLE
#3 Enhance run.sh to fail with clear error if npm not installed

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -1,3 +1,5 @@
+#!/bin/sh
+set -xe 
 cd ui
 npm install
 npm run compile && npm run bundle


### PR DESCRIPTION
This will fail if NPM not found as follows

`➜  swimos-traffic git:(run_sh_error_handling) ✗ sh ./run.sh
+ cd ui
/Users/jimzucker/Documents/dev-icloud-jim/swimos-traffic/ui
+ npm install
./run.sh: line 4: npm: command not found`

if no errors output will show each command executed
`➜  swimos-traffic git:(run_sh_error_handling) ✗ sh ./run.sh
+ cd ui
/Users/jimzucker/Documents/dev-icloud-jim/swimos-traffic/ui
+ npm install
npm WARN ERESOLVE overriding peer dependency`